### PR TITLE
Update minimum CMake version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@
 ##     Date:      2007-2017
 ##
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.14)
 
 project(qpOASES C)
 set(PACKAGE_NAME "qpOASES")


### PR DESCRIPTION
The CMake 3.5 version is no longer supported and won't compile anymore, while 3.14 is still retrocompatible to 3.5 but will compile. I therefore propose this change